### PR TITLE
Adding "Linux Support"

### DIFF
--- a/DTrackPlugin.uplugin
+++ b/DTrackPlugin.uplugin
@@ -17,12 +17,12 @@
 		{
 			"Name": "DTrackPlugin",
 			"Type": "Runtime",
-			"WhitelistPlatforms": [ "Win64" ]
+			"WhitelistPlatforms": [ "Win64" , "Linux" ]
 		},
 		{
 			"Name": "DTrackInput",
 			"Type": "Runtime",
-			"WhitelistPlatforms": [ "Win64" ]
+			"WhitelistPlatforms": [ "Win64" , "Linux" ]
 		}
 	],
 	"Plugins": [

--- a/Readme.md
+++ b/Readme.md
@@ -6,9 +6,6 @@ This is a plug-in for the Unreal Engine with the purpose of native integration o
 ## Prerequisites
 
 - Unreal Engine 4.23 or later
-- Windows
-- Microsoft Visual Studio 2015 or later (Express or Community Edition should suffice)
-
 
 ## Installation
 
@@ -17,7 +14,7 @@ This is a plug-in for the Unreal Engine with the purpose of native integration o
 - Adapt the _.uplugin_ file to the version of your _UnrealEditor_:<br>The `EngineVersion` key in the file _DTrackPlugin.uplugin_ comes with a default value corresponding to the latest tested _UE4Editor_ version (e.g. `"EngineVersion": "4.25.0"`).<br>If you are using an _UE4Editor_ version with a different minor version number (e.g. 4.23 instead of 4.25), you should adjust this value (e.g. to `"EngineVersion": "4.23.0"`).
 
 ### Install into the global Engine plugin folder
-- Compile the plugin manually:<br> *&lt;UE4Dir&gt;\Engine\Build\BatchFiles\RunUAT.bat* BuildPlugin -Plugin=*/Path/to/DTrackPlugin.uplugin* -TargetPlatforms=Win64 -Package=*&lt;OutDir&gt;* -Rocket
+- Compile the plugin manually:<br> *&lt;UE4Dir&gt;\Engine\Build\BatchFiles\RunUAT.bat* BuildPlugin -Plugin=*/Path/to/DTrackPlugin.uplugin* -TargetPlatforms=*&lt;Win64/Linux&gt;* -Package=*&lt;OutDir&gt;* -Rocket
 - Copy *&lt;OutDir&gt;* to *&lt;UE4Dir&gt;\Engine\Plugins\DTrackPlugin*
 
 

--- a/Source/DTrackPlugin/Public/DTrackSDKHandler.h
+++ b/Source/DTrackPlugin/Public/DTrackSDKHandler.h
@@ -28,12 +28,18 @@
 
 #include "ILiveLinkSource.h"
 
-// Avoid 'warning C4005' when including DTrackSDK
-#include "Windows/AllowWindowsPlatformTypes.h"
-#include "Windows/PreWindowsApi.h"
+#if PLATFORM_WINDOWS
+	// Avoid 'warning C4005' when including DTrackSDK
+	#include "Windows/AllowWindowsPlatformTypes.h"
+	#include "Windows/PreWindowsApi.h"
+#endif
+
 #include "DTrackSDK.hpp"
-#include "Windows/PostWindowsApi.h"
-#include "Windows/HideWindowsPlatformTypes.h"
+
+#if PLATFORM_WINDOWS
+	#include "Windows/PostWindowsApi.h"
+	#include "Windows/HideWindowsPlatformTypes.h"
+#endif
 
 #include "HAL/Runnable.h"
 #include "HAL/ThreadSafeBool.h"


### PR DESCRIPTION
While testing on our Linux cluster we noticed, that the plugin ran just fine under CentOS7 once the Windows include-guards are just added under windows.

Kind regards,
the Virtual Reality and Immersive Visualization Group of RWTH Aachen University