### PR TITLE
Adding specific keys for the flystick instead of mapping them on the gamepad

### DIFF
--- a/DTrackPlugin.uplugin
+++ b/DTrackPlugin.uplugin
@@ -17,12 +17,12 @@
 		{
 			"Name": "DTrackPlugin",
 			"Type": "Runtime",
-			"WhitelistPlatforms": [ "Win64" ]
+			"WhitelistPlatforms": [ "Win64" , "Linux" ]
 		},
 		{
 			"Name": "DTrackInput",
 			"Type": "Runtime",
-			"WhitelistPlatforms": [ "Win64" ]
+			"WhitelistPlatforms": [ "Win64" , "Linux" ]
 		}
 	],
 	"Plugins": [

--- a/Readme.md
+++ b/Readme.md
@@ -6,9 +6,6 @@ This is a plug-in for the Unreal Engine with the purpose of native integration o
 ## Prerequisites
 
 - Unreal Engine 4.23 or later
-- Windows
-- Microsoft Visual Studio 2015 or later (Express or Community Edition should suffice)
-
 
 ## Installation
 
@@ -17,7 +14,7 @@ This is a plug-in for the Unreal Engine with the purpose of native integration o
 - Adapt the _.uplugin_ file to the version of your _UnrealEditor_:<br>The `EngineVersion` key in the file _DTrackPlugin.uplugin_ comes with a default value corresponding to the latest tested _UE4Editor_ version (e.g. `"EngineVersion": "4.25.0"`).<br>If you are using an _UE4Editor_ version with a different minor version number (e.g. 4.23 instead of 4.25), you should adjust this value (e.g. to `"EngineVersion": "4.23.0"`).
 
 ### Install into the global Engine plugin folder
-- Compile the plugin manually:<br> *&lt;UE4Dir&gt;\Engine\Build\BatchFiles\RunUAT.bat* BuildPlugin -Plugin=*/Path/to/DTrackPlugin.uplugin* -TargetPlatforms=Win64 -Package=*&lt;OutDir&gt;* -Rocket
+- Compile the plugin manually:<br> *&lt;UE4Dir&gt;\Engine\Build\BatchFiles\RunUAT.bat* BuildPlugin -Plugin=*/Path/to/DTrackPlugin.uplugin* -TargetPlatforms=*&lt;Win64/Linux&gt;* -Package=*&lt;OutDir&gt;* -Rocket
 - Copy *&lt;OutDir&gt;* to *&lt;UE4Dir&gt;\Engine\Plugins\DTrackPlugin*
 
 

--- a/Source/DTrackInput/Private/DTrackFlystickInputDevice.cpp
+++ b/Source/DTrackInput/Private/DTrackFlystickInputDevice.cpp
@@ -52,18 +52,18 @@ FDTrackFlystickInputDevice::FDTrackFlystickInputDevice(const TSharedRef< FGeneri
 		ModularFeatures.OnModularFeatureRegistered().AddRaw(this, &FDTrackFlystickInputDevice::on_modular_feature_registerd);
 	}
 
-	m_button_mapping.Add( EKeys::Gamepad_LeftTrigger.GetFName() );
-	m_button_mapping.Add( EKeys::Gamepad_FaceButton_Bottom.GetFName() );
-	m_button_mapping.Add( EKeys::Gamepad_FaceButton_Right.GetFName() );
-	m_button_mapping.Add( EKeys::Gamepad_FaceButton_Left.GetFName() );
-	m_button_mapping.Add( EKeys::Gamepad_FaceButton_Top.GetFName() );
-	m_button_mapping.Add( EKeys::Gamepad_DPad_Up.GetFName() );
-	m_button_mapping.Add( EKeys::Gamepad_DPad_Down.GetFName() );
-	m_button_mapping.Add( EKeys::Gamepad_DPad_Right.GetFName() );
-	m_button_mapping.Add( EKeys::Gamepad_DPad_Left.GetFName() );
+	m_button_mapping.Add( FDTrackInputModule::FlystickTrigger.GetFName() );
+	m_button_mapping.Add( FDTrackInputModule::FlystickButton1.GetFName() );
+	m_button_mapping.Add( FDTrackInputModule::FlystickButton2.GetFName() );
+	m_button_mapping.Add( FDTrackInputModule::FlystickButton3.GetFName() );
+	m_button_mapping.Add( FDTrackInputModule::FlystickButton4.GetFName() );
+	m_button_mapping.Add( FDTrackInputModule::FlystickButton5.GetFName() );
+	m_button_mapping.Add( FDTrackInputModule::FlystickButton6.GetFName() );
+	m_button_mapping.Add( FDTrackInputModule::FlystickButton7.GetFName() );
+	m_button_mapping.Add( FDTrackInputModule::FlystickButton8.GetFName() );
 
-	m_joystick_mapping.Add( EKeys::Gamepad_LeftX.GetFName() );
-	m_joystick_mapping.Add( EKeys::Gamepad_LeftY.GetFName() );
+	m_joystick_mapping.Add( FDTrackInputModule::FlystickThumbstickX.GetFName() );
+	m_joystick_mapping.Add( FDTrackInputModule::FlystickThumbstickY.GetFName() );
 }
 
 FDTrackFlystickInputDevice::~FDTrackFlystickInputDevice() {

--- a/Source/DTrackInput/Private/DTrackInputModule.cpp
+++ b/Source/DTrackInput/Private/DTrackInputModule.cpp
@@ -32,9 +32,35 @@
 
 DEFINE_LOG_CATEGORY(LogDTrackInput);
 
-
+/* Keys */
+const FKey FDTrackInputModule::FlystickTrigger = FKey("Flystick_Trigger");
+const FKey FDTrackInputModule::FlystickButton1 = FKey("Flystick_Button_1");
+const FKey FDTrackInputModule::FlystickButton2 = FKey("Flystick_Button_2");
+const FKey FDTrackInputModule::FlystickButton3 = FKey("Flystick_Button_3");
+const FKey FDTrackInputModule::FlystickButton4 = FKey("Flystick_Button_4");
+const FKey FDTrackInputModule::FlystickButton5 = FKey("Flystick_Button_5");
+const FKey FDTrackInputModule::FlystickButton6 = FKey("Flystick_Button_6");
+const FKey FDTrackInputModule::FlystickButton7 = FKey("Flystick_Button_7");
+const FKey FDTrackInputModule::FlystickButton8 = FKey("Flystick_Button_8");
+/* Axis */
+const FKey FDTrackInputModule::FlystickThumbstickX = FKey("Flystick_Thumbstick_X");
+const FKey FDTrackInputModule::FlystickThumbstickY = FKey("Flystick_Thumbstick_Y");
 
 TSharedPtr< class IInputDevice > FDTrackInputModule::CreateInputDevice(const TSharedRef< FGenericApplicationMessageHandler >& InMessageHandler) {
+	EKeys::AddMenuCategoryDisplayInfo(FlystickKeyCategory, FText::AsCultureInvariant("A.R.T. Flystick"), TEXT("GraphEditor.PadEvent_16x"));
+	
+	EKeys::AddKey(FKeyDetails(FlystickTrigger, FText::AsCultureInvariant("Flystick Trigger"), FKeyDetails::GamepadKey, FlystickKeyCategory));
+	EKeys::AddKey(FKeyDetails(FlystickButton1, FText::AsCultureInvariant("Flystick Button 1"), FKeyDetails::GamepadKey, FlystickKeyCategory));
+	EKeys::AddKey(FKeyDetails(FlystickButton2, FText::AsCultureInvariant("Flystick Button 2"), FKeyDetails::GamepadKey, FlystickKeyCategory));
+	EKeys::AddKey(FKeyDetails(FlystickButton3, FText::AsCultureInvariant("Flystick Button 3"), FKeyDetails::GamepadKey, FlystickKeyCategory));
+	EKeys::AddKey(FKeyDetails(FlystickButton4, FText::AsCultureInvariant("Flystick Button 4"), FKeyDetails::GamepadKey, FlystickKeyCategory));
+	EKeys::AddKey(FKeyDetails(FlystickButton5, FText::AsCultureInvariant("Flystick Button 5"), FKeyDetails::GamepadKey, FlystickKeyCategory));
+	EKeys::AddKey(FKeyDetails(FlystickButton6, FText::AsCultureInvariant("Flystick Button 6"), FKeyDetails::GamepadKey, FlystickKeyCategory));
+	EKeys::AddKey(FKeyDetails(FlystickButton7, FText::AsCultureInvariant("Flystick Button 7"), FKeyDetails::GamepadKey, FlystickKeyCategory));
+	EKeys::AddKey(FKeyDetails(FlystickButton8, FText::AsCultureInvariant("Flystick Button 8"), FKeyDetails::GamepadKey, FlystickKeyCategory));
+	EKeys::AddKey(FKeyDetails(FlystickThumbstickX,  FText::AsCultureInvariant("Flystick Thumbstick X"), FKeyDetails::GamepadKey | FKeyDetails::Axis1D, FlystickKeyCategory));
+	EKeys::AddKey(FKeyDetails(FlystickThumbstickY,  FText::AsCultureInvariant("Flystick Thumbstick Y"), FKeyDetails::GamepadKey | FKeyDetails::Axis1D, FlystickKeyCategory));
+	
 	return TSharedPtr< class IInputDevice >(new FDTrackFlystickInputDevice(InMessageHandler));
 }
 

--- a/Source/DTrackInput/Private/DTrackInputModule.h
+++ b/Source/DTrackInput/Private/DTrackInputModule.h
@@ -28,6 +28,7 @@
 
 
 #include "IDTrackInputModule.h"
+#include "InputCoreTypes.h"
 
 class FDTrackFlystickInputDevice;
 class ILiveLinkClient;
@@ -42,7 +43,23 @@ DECLARE_LOG_CATEGORY_EXTERN(LogDTrackInput, Log, All);
 class FDTrackInputModule : public IDTrackInputModule
 {
 public:
-
+	
+	/* Category */
+	const FName FlystickKeyCategory = FName("ART_Flystick");
+	/* Keys */
+	static const FKey FlystickTrigger;
+	static const FKey FlystickButton1;
+	static const FKey FlystickButton2;
+	static const FKey FlystickButton3;
+	static const FKey FlystickButton4;
+	static const FKey FlystickButton5;
+	static const FKey FlystickButton6;
+	static const FKey FlystickButton7;
+	static const FKey FlystickButton8;
+	/* Axis */
+	static const FKey FlystickThumbstickX;
+	static const FKey FlystickThumbstickY;
+	
 	//~ Begin IInputDeviceModule implementation
 	virtual TSharedPtr< class IInputDevice > CreateInputDevice(const TSharedRef< FGenericApplicationMessageHandler >& InMessageHandler) override;
 	//~ End IInputDeviceModule implementation

--- a/Source/DTrackPlugin/Public/DTrackSDKHandler.h
+++ b/Source/DTrackPlugin/Public/DTrackSDKHandler.h
@@ -28,12 +28,18 @@
 
 #include "ILiveLinkSource.h"
 
-// Avoid 'warning C4005' when including DTrackSDK
-#include "Windows/AllowWindowsPlatformTypes.h"
-#include "Windows/PreWindowsApi.h"
+#if PLATFORM_WINDOWS
+	// Avoid 'warning C4005' when including DTrackSDK
+	#include "Windows/AllowWindowsPlatformTypes.h"
+	#include "Windows/PreWindowsApi.h"
+#endif
+
 #include "DTrackSDK.hpp"
-#include "Windows/PostWindowsApi.h"
-#include "Windows/HideWindowsPlatformTypes.h"
+
+#if PLATFORM_WINDOWS
+	#include "Windows/PostWindowsApi.h"
+	#include "Windows/HideWindowsPlatformTypes.h"
+#endif
 
 #include "HAL/Runnable.h"
 #include "HAL/ThreadSafeBool.h"


### PR DESCRIPTION
Instead of mapping the flystick keys onto the predefined gamepad keys, separate special flystick keys are added and used internally.

Kind regards,
the Virtual Reality and Immersive Visualization Group of RWTH Aachen University